### PR TITLE
test: ensure canary tests clean up created resources on failure

### DIFF
--- a/src/BasisTheory.Client.Test/AgenticTests.cs
+++ b/src/BasisTheory.Client.Test/AgenticTests.cs
@@ -10,6 +10,59 @@ namespace BasisTheory.Client.Test;
 [TestFixture]
 public class AgenticTests
 {
+    private readonly List<string> _createdAgentIds = new();
+    private readonly List<string> _createdEnrollmentIds = new();
+    private readonly List<(string AgentId, string InstructionId)> _createdInstructions = new();
+
+    [TearDown]
+    public async Task CleanUpCreatedResources()
+    {
+        var client = GetClient();
+
+        // Instructions belong to an agent, so delete them before their agents.
+        foreach (var (agentId, instructionId) in _createdInstructions)
+            await TryDelete(() => client.Agentic.Agents.Instructions.DeleteAsync(agentId, instructionId));
+        foreach (var enrollmentId in _createdEnrollmentIds)
+            await TryDelete(() => client.Agentic.Enrollments.DeleteAsync(enrollmentId));
+        foreach (var agentId in _createdAgentIds)
+            await TryDelete(() => client.Agentic.Agents.DeleteAsync(agentId));
+
+        _createdInstructions.Clear();
+        _createdEnrollmentIds.Clear();
+        _createdAgentIds.Clear();
+    }
+
+    private static async Task TryDelete(Func<Task> delete)
+    {
+        try
+        {
+            await delete();
+        }
+        catch (Exception e)
+        {
+            // Best-effort cleanup: an already-deleted or failed resource must not mask the test result.
+            TestContext.Out.WriteLine($"Failed to clean up test resource: {e.Message}");
+        }
+    }
+
+    private void TrackAgent(string? agentId)
+    {
+        if (agentId != null)
+            _createdAgentIds.Add(agentId);
+    }
+
+    private void TrackEnrollment(string? enrollmentId)
+    {
+        if (enrollmentId != null)
+            _createdEnrollmentIds.Add(enrollmentId);
+    }
+
+    private void TrackInstruction(string? agentId, string? instructionId)
+    {
+        if (agentId != null && instructionId != null)
+            _createdInstructions.Add((agentId, instructionId));
+    }
+
     private static BasisTheory GetClient()
     {
         return new BasisTheory(Environment.GetEnvironmentVariable("BT_PVT_TEST_API_KEY"),
@@ -51,7 +104,7 @@ public class AgenticTests
         };
     }
 
-    private static async Task<Enrollment> CreateAndVerifyEnrollment(
+    private async Task<Enrollment> CreateAndVerifyEnrollment(
         BasisTheory client, string cardNumber, string email, IEnumerable<string>? agentIds = null)
     {
         var tokenId = await CreateCardToken(client, cardNumber);
@@ -61,6 +114,7 @@ public class AgenticTests
             Consumer = new Consumer { Email = email },
             AgentIds = agentIds,
         });
+        TrackEnrollment(enrollment.Id);
 
         // Start verification
         var verifyResponse = await client.Agentic.Enrollments.Verify.StartAsync(enrollment.Id!, new StartVerificationRequest
@@ -103,6 +157,7 @@ public class AgenticTests
         {
             Name = agentName,
         });
+        TrackAgent(agent.Id);
         Assert.That(agent.Id, Is.Not.Null);
         Assert.That(agent.Name, Is.EqualTo(agentName));
         Assert.That(agent.Status, Is.EqualTo("active"));
@@ -213,6 +268,7 @@ public class AgenticTests
                 Email = "sdk-test-otp@example.com",
             },
         });
+        TrackEnrollment(enrollment.Id);
         Assert.That(enrollment.Id, Is.Not.Null);
         Assert.That(enrollment.Status, Is.EqualTo(EnrollmentStatus.PendingVerification));
         Assert.That(enrollment.Provider, Is.Not.Null);
@@ -282,6 +338,7 @@ public class AgenticTests
         {
             Name = "(Deletable) dotnet-SDK-instruction-agent-" + Guid.NewGuid(),
         });
+        TrackAgent(agent.Id);
 
         var enrollment = await CreateAndVerifyEnrollment(client, "4000056655665556", "sdk-test-instructions@example.com", [agent.Id!]);
         Assert.That(enrollment.Status, Is.EqualTo(EnrollmentStatus.Active));
@@ -300,6 +357,7 @@ public class AgenticTests
             Description = "(Deletable) dotnet-SDK test purchase",
             ExpiresAt = expiresAt,
         });
+        TrackInstruction(agent.Id, instruction.Id);
         Assert.That(instruction.Id, Is.Not.Null);
         Assert.That(instruction.EnrollmentId, Is.EqualTo(enrollment.Id));
         Assert.That(instruction.Status, Is.EqualTo(InstructionStatus.PendingVerification));
@@ -405,6 +463,7 @@ public class AgenticTests
         {
             Name = "(Deletable) dotnet-SDK-filter-agent-" + Guid.NewGuid(),
         });
+        TrackAgent(agent.Id);
 
         var enrollment = await CreateAndVerifyEnrollment(client, "4000056655665556", "sdk-test-filter@example.com", [agent.Id!]);
 
@@ -417,6 +476,7 @@ public class AgenticTests
             Description = "(Deletable) dotnet-SDK filter test",
             ExpiresAt = expiresAt,
         });
+        TrackInstruction(agent.Id, instruction.Id);
 
         // Verify created instruction fields
         Assert.That(instruction.Id, Is.Not.Null);

--- a/src/BasisTheory.Client.Test/TestClient.cs
+++ b/src/BasisTheory.Client.Test/TestClient.cs
@@ -8,6 +8,41 @@ namespace BasisTheory.Client.Test;
 [TestFixture]
 public class TestClient
 {
+    private readonly List<string> _createdApplicationIds = new();
+    private readonly List<string> _createdProxyIds = new();
+    private readonly List<string> _createdReactorIds = new();
+
+    [TearDown]
+    public async Task CleanUpCreatedResources()
+    {
+        var managementClient = GetManagementClient();
+
+        // Proxies and reactors reference their backing application, so delete them first.
+        foreach (var proxyId in _createdProxyIds)
+            await TryDelete(() => managementClient.Proxies.DeleteAsync(proxyId));
+        foreach (var reactorId in _createdReactorIds)
+            await TryDelete(() => managementClient.Reactors.DeleteAsync(reactorId));
+        foreach (var applicationId in _createdApplicationIds)
+            await TryDelete(() => managementClient.Applications.DeleteAsync(applicationId));
+
+        _createdProxyIds.Clear();
+        _createdReactorIds.Clear();
+        _createdApplicationIds.Clear();
+    }
+
+    private static async Task TryDelete(Func<Task> delete)
+    {
+        try
+        {
+            await delete();
+        }
+        catch (Exception e)
+        {
+            // Best-effort cleanup: an already-deleted or failed resource must not mask the test result.
+            TestContext.Out.WriteLine($"Failed to clean up test resource: {e.Message}");
+        }
+    }
+
     [Test]
     public async Task ShouldGetTenantSelf()
     {
@@ -21,6 +56,7 @@ public class TestClient
     {
         var client = GetManagementClient();
         var applicationId = await CreateApplication(client);
+        TrackApplication(applicationId);
         var proxy = await client.Proxies.CreateAsync(new CreateProxyRequest
         {
             Name = "(Deletable) dotnet-sdk-" + Guid.NewGuid(),
@@ -62,6 +98,7 @@ public class TestClient
             RequireAuth = true
         });
         var proxyId = proxy.Id;
+        TrackProxy(proxyId);
 
         var updatedProxy = await client.Proxies.UpdateAsync(
             proxyId,
@@ -129,6 +166,7 @@ public class TestClient
     {
         var managementClient = GetManagementClient();
         var applicationId = await CreateApplication(managementClient);
+        TrackApplication(applicationId);
         var reactor = await managementClient.Reactors.CreateAsync(new CreateReactorRequest
         {
             Name = "(Deletable) dotnet-sdk-" + Guid.NewGuid(),
@@ -152,6 +190,7 @@ public class TestClient
             }
         });
         var reactorId = reactor.Id;
+        TrackReactor(reactorId);
 
         var updatedReactor = await managementClient.Reactors.UpdateAsync(
             reactorId,
@@ -238,13 +277,16 @@ public class TestClient
 
         // Create Application
         var applicationId = await CreateApplication(managementClient);
+        TrackApplication(applicationId);
 
         // Proxies
         var proxyId = await CreateProxy(managementClient, applicationId);
+        TrackProxy(proxyId);
         await managementClient.Proxies.DeleteAsync(proxyId);
 
         // Reactors
         var reactorId = await CreateReactor(managementClient, applicationId);
+        TrackReactor(reactorId);
         await React(client, reactorId);
         await managementClient.Reactors.DeleteAsync(reactorId);
 
@@ -857,6 +899,24 @@ public class TestClient
     private static void AssertIsGuid(string? expected)
     {
         Assert.That(Guid.TryParse(expected, out Guid _), Is.True);
+    }
+
+    private void TrackApplication(string? applicationId)
+    {
+        if (applicationId != null)
+            _createdApplicationIds.Add(applicationId);
+    }
+
+    private void TrackProxy(string? proxyId)
+    {
+        if (proxyId != null)
+            _createdProxyIds.Add(proxyId);
+    }
+
+    private void TrackReactor(string? reactorId)
+    {
+        if (reactorId != null)
+            _createdReactorIds.Add(reactorId);
     }
 
     private static async Task<string?> CreateApplication(BasisTheory managementClient)


### PR DESCRIPTION
## Description
- The canary/integration test creates applications, proxies, and reactors named `(Deletable) dotnet-sdk-<uuid>` but deleted them with inline calls at the end of the happy path — so any earlier assertion or API failure left the resources orphaned in the shared dev tenant. This test runs on every PR against the dev API, so orphans accumulated over time.
- Fix: Track created resource ids and delete them in an NUnit `[TearDown]` via a best-effort `TryDelete` helper (proxies/reactors before their application). TearDown runs after every test regardless of failure.
- Cleanup is best-effort (a failed delete of one resource is logged and never blocks the others or masks the original test failure). No test assertions, created resources, or names changed — only teardown was made guaranteed.

## Business Impact
- Stops this SDK's canary runs from leaking orphaned applications/proxies/reactors into the shared dev tenant on any failed/partial run.

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
- N/A

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
